### PR TITLE
Updated to reflect Sequelize deprecation of String based operators

### DIFF
--- a/index.js
+++ b/index.js
@@ -76,7 +76,7 @@ class SequelizeStore extends EventEmitter {
         where: {
           id: sid,
           expires: {
-            $gt: Math.floor(Date.now() / 1000)
+            [this.sequelize.Sequelize.Op.gt]: Math.floor(Date.now() / 1000)
           }
         }
       }).then(row => {


### PR DESCRIPTION
Removed use of String based query operators, similar to:
https://github.com/sequelize/sequelize/issues/8417

See: http://docs.sequelizejs.com/manual/tutorial/querying.html#operators